### PR TITLE
FIX: fix typo

### DIFF
--- a/vnpy_rqdata/rqdata_gateway.py
+++ b/vnpy_rqdata/rqdata_gateway.py
@@ -101,7 +101,7 @@ class RqdataGateway(BaseGateway):
 
         # 订阅之前行情
         for rq_channel in self.subscribed:
-            self.clicent.subscrbie(rq_channel)
+            self.client.subscrbie(rq_channel)
 
         self.write_log("RQData接口初始化成功")
 


### PR DESCRIPTION
fix typo which cause AttributeError: 'RqdataGateway' object has no attribute 'clicent'. Did you mean: 'client'?

建议每次发起的PR内容尽可能精简，复杂的修改请拆分为多次PR，便于管理合并。

## 改进内容

1. 修复变量引用手误

## 相关的Issue号（如有）

Close #